### PR TITLE
Enable additional query options for caches

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import com.orbitz.consul.ConsulException;
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.ConsulResponse;
+import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.QueryOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +16,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 /**
@@ -164,7 +166,20 @@ public class ConsulCache<K, V> {
         }
     }
 
-    protected static QueryOptions watchParams(BigInteger index, int blockSeconds) {
+    protected static QueryOptions watchParams(final BigInteger index, final int blockSeconds,
+                                              QueryOptions queryOptions) {
+        checkArgument(!queryOptions.getIndex().isPresent() && !queryOptions.getWait().isPresent(),
+                "Index and wait cannot be overridden");
+
+        return ImmutableQueryOptions.builder()
+                .from(watchDefaultParams(index, blockSeconds))
+                .token(queryOptions.getToken())
+                .consistencyMode(queryOptions.getConsistencyMode())
+                .near(queryOptions.getNear())
+                .build();
+    }
+
+    private static QueryOptions watchDefaultParams(final BigInteger index, final int blockSeconds) {
         if (index == null) {
             return QueryOptions.BLANK;
         } else {

--- a/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
+++ b/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
@@ -30,7 +30,7 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
             final com.orbitz.consul.model.State state,
             final CatalogOptions catalogOptions,
             final int watchSeconds,
-            final QueryOptions additionalQueryOptions) {
+            final QueryOptions queryOptions) {
         Function<HealthCheck, String> keyExtractor = new Function<HealthCheck, String>() {
             @Override
             public String apply(HealthCheck input) {
@@ -41,8 +41,8 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
         CallbackConsumer<HealthCheck> callbackConsumer = new CallbackConsumer<HealthCheck>() {
             @Override
             public void consume(BigInteger index, ConsulResponseCallback<List<HealthCheck>> callback) {
-                QueryOptions queryOptions = watchParams(index, watchSeconds, additionalQueryOptions);
-                healthClient.getChecksByState(state, catalogOptions, queryOptions, callback);
+                QueryOptions params = watchParams(index, watchSeconds, queryOptions);
+                healthClient.getChecksByState(state, catalogOptions, params, callback);
             }
         };
 

--- a/src/main/java/com/orbitz/consul/cache/KVCache.java
+++ b/src/main/java/com/orbitz/consul/cache/KVCache.java
@@ -24,7 +24,7 @@ public class KVCache extends ConsulCache<String, Value> {
             final KeyValueClient kvClient,
             final String rootPath,
             final int watchSeconds,
-            final QueryOptions additionalQueryOptions) {
+            final QueryOptions queryOptions) {
 
         final Set<String> rootPathSegments =
                 new LinkedHashSet<>(Arrays.asList(rootPath.split("/")));
@@ -42,8 +42,8 @@ public class KVCache extends ConsulCache<String, Value> {
         final CallbackConsumer<Value> callbackConsumer = new CallbackConsumer<Value>() {
             @Override
             public void consume(BigInteger index, ConsulResponseCallback<List<Value>> callback) {
-                QueryOptions queryOptions = watchParams(index, watchSeconds, additionalQueryOptions);
-                kvClient.getValues(rootPath, queryOptions, callback);
+                QueryOptions params = watchParams(index, watchSeconds, queryOptions);
+                kvClient.getValues(rootPath, params, callback);
             }
         };
 

--- a/src/main/java/com/orbitz/consul/cache/KVCache.java
+++ b/src/main/java/com/orbitz/consul/cache/KVCache.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Sets;
 import com.orbitz.consul.KeyValueClient;
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.kv.Value;
+import com.orbitz.consul.option.QueryOptions;
 import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigInteger;
@@ -19,18 +20,11 @@ public class KVCache extends ConsulCache<String, Value> {
         super(keyConversion, callbackConsumer);
     }
 
-    /**
-     * Factory method to construct a String/{@link Value} map with a 10 second
-     * block interval
-     *
-     * @param kvClient the {@link KeyValueClient} to use
-     * @param rootPath the root path
-     * @return the cache object
-     */
     public static KVCache newCache(
             final KeyValueClient kvClient,
             final String rootPath,
-            final int watchSeconds) {
+            final int watchSeconds,
+            final QueryOptions additionalQueryOptions) {
 
         final Set<String> rootPathSegments =
                 new LinkedHashSet<>(Arrays.asList(rootPath.split("/")));
@@ -48,10 +42,32 @@ public class KVCache extends ConsulCache<String, Value> {
         final CallbackConsumer<Value> callbackConsumer = new CallbackConsumer<Value>() {
             @Override
             public void consume(BigInteger index, ConsulResponseCallback<List<Value>> callback) {
-                kvClient.getValues(rootPath, watchParams(index, watchSeconds), callback);
+                QueryOptions queryOptions = watchParams(index, watchSeconds, additionalQueryOptions);
+                kvClient.getValues(rootPath, queryOptions, callback);
             }
         };
 
         return new KVCache(keyExtractor, callbackConsumer);
+    }
+
+    public static KVCache newCache(
+            final KeyValueClient kvClient,
+            final String rootPath,
+            final int watchSeconds) {
+        return newCache(kvClient, rootPath, watchSeconds, QueryOptions.BLANK);
+    }
+
+    /**
+     * Factory method to construct a String/{@link Value} map with a 10 second
+     * block interval
+     *
+     * @param kvClient the {@link KeyValueClient} to use
+     * @param rootPath the root path
+     * @return the cache object
+     */
+    public static KVCache newCache(
+            final KeyValueClient kvClient,
+            final String rootPath) {
+        return newCache(kvClient, rootPath, 10);
     }
 }

--- a/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
@@ -33,7 +33,7 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
             final boolean passing,
             final CatalogOptions catalogOptions,
             final int watchSeconds,
-            final QueryOptions additionalQueryOptions) {
+            final QueryOptions queryOptions) {
         Function<ServiceHealth, ServiceHealthKey> keyExtractor = new Function<ServiceHealth, ServiceHealthKey>() {
             @Override
             public ServiceHealthKey apply(ServiceHealth input) {
@@ -44,11 +44,11 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
         CallbackConsumer<ServiceHealth> callbackConsumer = new CallbackConsumer<ServiceHealth>() {
             @Override
             public void consume(BigInteger index, ConsulResponseCallback<List<ServiceHealth>> callback) {
-                QueryOptions queryOptions = watchParams(index, watchSeconds, additionalQueryOptions);
+                QueryOptions params = watchParams(index, watchSeconds, queryOptions);
                 if (passing) {
-                    healthClient.getHealthyServiceInstances(serviceName, catalogOptions, queryOptions, callback);
+                    healthClient.getHealthyServiceInstances(serviceName, catalogOptions, params, callback);
                 } else {
-                    healthClient.getAllServiceInstances(serviceName, catalogOptions, queryOptions, callback);
+                    healthClient.getAllServiceInstances(serviceName, catalogOptions, params, callback);
                 }
             }
         };


### PR DESCRIPTION
Allow override of query options for caches (HealthCheck, ServiceHealth and
KeyValue). Consistency mode, token and near can now be specified for caches.