### PR TITLE
Fix flaky "lifecycle" tests in ConsulCacheTest

### DIFF
--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -21,6 +21,8 @@ import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.mock;
 import static org.junit.Assert.*;
 
@@ -278,7 +280,7 @@ public class ConsulCacheTest extends BaseIntegrationTest {
 
         assertEquals(ConsulCache.State.latent, nc.getState());
         nc.start();
-        assertEquals(ConsulCache.State.starting, nc.getState());
+        assertThat(nc.getState(), anyOf(is(ConsulCache.State.starting), is(ConsulCache.State.started)));
 
         if (!nc.awaitInitialized(10, TimeUnit.SECONDS)) {
             fail("cache initialization failed");
@@ -299,7 +301,7 @@ public class ConsulCacheTest extends BaseIntegrationTest {
         assertEquals(ConsulCache.State.latent, nc.getState());
 
         nc.start();
-        assertEquals(ConsulCache.State.starting, nc.getState());
+        assertThat(nc.getState(), anyOf(is(ConsulCache.State.starting), is(ConsulCache.State.started)));
 
         if (!nc.awaitInitialized(1, TimeUnit.SECONDS)) {
             fail("cache initialization failed");


### PR DESCRIPTION
The tests start the cache and expected it to be starting, then started.
But it the cache starts "fast", it will be directly started and the test will fail.
Fix it by requiring the cache to be either starting or started.